### PR TITLE
Use HTTPS to avoid mixed content errors

### DIFF
--- a/_layouts/video.html
+++ b/_layouts/video.html
@@ -45,7 +45,7 @@
 			<div id="video-player" class="video-player-wrap">
 				<div class="video-player">
 					<div class="embed-responsive embed-responsive-16by9">
-		      	<iframe class="embed-responsive-item" src='http://www.youtube.com/embed/{{ page.youtube_id }}?autoplay=1'
+		      	<iframe class="embed-responsive-item" src='https://www.youtube.com/embed/{{ page.youtube_id }}?autoplay=1'
 		      		        itemprop='embedUrl'
 		      		        frameborder='0'
 		      	          allowfullscreen>


### PR DESCRIPTION
Fix for https://github.com/magento/devdocs/issues/1815