### PR TITLE
Add language support to layout files

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ defaults:
       path: "" # an empty string here means all files in the project
     values:
       layout: "default"
+      lang: "en"
   -
     scope:
       path: ""

--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr">
+<html lang="{{ page.lang }}" dir="ltr">
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width initial-scale=1" />


### PR DESCRIPTION
This PR adds `page.lang` to the layout header so if the page has a language, it will be respected in layout. This will improve SEO for multilingual websites like http://omsdocs.magento.com.

For websites with the single language, it can be configured in _config.yml:

```
defaults:
  -
    scope:
      path: "" # an empty string here means all files in the project
    values:
      layout: "default"
      lang: "en"
```