### PR TITLE
Update jQuery to latest version

### DIFF
--- a/_includes/layout/footer.html
+++ b/_includes/layout/footer.html
@@ -6,7 +6,7 @@
 
 {% include layout/page-footer.html %}
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
 <script src="https://cdn.jsdelivr.net/algoliasearch/3/algoliasearch.min.js"></script>
 <script src="{{ site.baseurl }}/assets/js/app.min.js"></script>
 


### PR DESCRIPTION
This PR adds the jQuery 3.3.1 to be used instead of 2.2.3