### PR TITLE
Remove rel=“canonical” from header

### DIFF
--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -14,8 +14,6 @@
 	{% include layout/header-styles.html %}
 	{% include layout/header-scripts.html %}
 
-	<link rel="canonical" href="{{ page.url | replace:'/index.html','' | prepend: site.baseurl | prepend: site.url }}">
-
 	<link rel="shortcut icon" type="image/vnd.microsoft.icon" href="https://magento.com/favicon.ico">
 	<link rel="apple-touch-icon" type="image/png" href="https://magento.com/apple-touch-icon.png">
 	<link rel="apple-touch-icon" type="image/png" sizes="57x57" href="https://magento.com/apple-touch-icon-57x57.png">

--- a/_includes/layout/site-nav.html
+++ b/_includes/layout/site-nav.html
@@ -18,12 +18,12 @@
     </div>
 
     <div class="search-btn">
-      <button class="search-trigger search-icon"></button>
+      <button class="search-trigger search-icon" aria-label="Search"></button>
     </div>
 
     <form class="quick-search" action="{{ site.baseurl }}/search/" method="get" novalidate="novalidate">
       <input type="search" name="q" placeholder="Search" />
-      <button class="quick-search-close">&times;</button>
+      <button class="quick-search-close" aria-label="Close search">&times;</button>
     </form>
 
   </div>


### PR DESCRIPTION
This PR will remove the rel="canonical" from the theme. 
Each website should control how canonical URLs are declared within `_include/layout/header-styles.html` from now on.