### PR TITLE
Ignore empty logo link for multi-repo builds

### DIFF
--- a/_includes/layout/site-nav.html
+++ b/_includes/layout/site-nav.html
@@ -6,7 +6,7 @@
 
   <div class="nav-container">
 
-    <a class="logo" href="{{ site.baseurl }}/">
+    <a class="logo" data-proofer-ignore href="{{ site.baseurl }}/">
       <img src="{{ site.baseurl }}/assets/i/m-logo.svg" alt="">
       <img src="{{ site.baseurl }}/assets/i/magento-logo.svg" alt="Magento" class="magento-logo" />
       <span class="site-logo">{{ site.logo }}</span>


### PR DESCRIPTION
Without this attribute, the link checker fails on multi-repo builds because multi-repo builds don't contain the elements necessary for the liquid templating expression to build the link.