### PR TITLE
Add new include just after the body tag

### DIFF
--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -27,16 +27,13 @@
 
 </head>
 <body class="layout-{{ page.layout }}">
+{% include layout/after-body.html %}
 
 	<header class="site-header">
-
 		{% include layout/site-nav.html %}
-
 	</header>
 
 	<div class="global-wrapper">
-
 		{% include layout/after-site-header.html %}
-
 		<div class="main-container">
 			<a id="main-content"></a>


### PR DESCRIPTION
This will add the ability to insert code just after the `<body>` tag for GTM verification and other purposes (maybe site-wide banners on top of the main navigation).