### PR TITLE
Remove Marketplace User Guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -88,6 +88,3 @@ app_switcher:
 
       - label: Business Intelligence
         url: https://docs.magento.com/mbi/
-
-      - label: Marketplace
-        url: https://docs.magento.com/marketplace/user_guide/getting-started.html

--- a/_includes/layout/header-scripts.html
+++ b/_includes/layout/header-scripts.html
@@ -30,11 +30,6 @@
       baseUrl: "https://docs.magento.com/mbi"
     },
     {
-      label: "Marketplace User Guide",
-      name: "merchdocs-marketplace",
-      baseUrl: "https://docs.magento.com/marketplace/user_guide"
-    },
-    {
       label: "PWA",
       name: "pwa-devdocs",
       baseUrl: "https://magento.github.io/pwa-studio"


### PR DESCRIPTION
This PR removes the Marketplace User Guide from the federated search and as an item in the site switcher. 