### PR TITLE
Update the merchdocs index and site url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -89,7 +89,7 @@ app_switcher:
       children:
 
       - label: Commerce User Guide
-        url: https://docs.magento.com/m2/ee/user_guide/
+        url: https://docs.magento.com/user-guide/
 
       - label: Order Management
         url: https://omsdocs.magento.com/en/userguides/

--- a/_includes/layout/header-scripts.html
+++ b/_includes/layout/header-scripts.html
@@ -21,8 +21,8 @@
     },
     {
       label: "User Guide",
-      name: "merchdocs_ee",
-      baseUrl: "https://docs.magento.com/m2/ee/user_guide"
+      name: "merchdocs",
+      baseUrl: "https://docs.magento.com/user-guide"
     },
     {
       label: "MBI User Guide",


### PR DESCRIPTION
1. Changes the app switcher URL to use the new user-guide address.
2. Updates the federated search with new index (has to be done on all the websites)

NOTE:  It’s basically a template for updating all the websites with new URL.