### PR TITLE
Fix gemspec

### DIFF
--- a/devdocs.gemspec
+++ b/devdocs.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jekyll', '>= 4.0'
   spec.add_development_dependency 'bundler', '>= 1.12'
-  spec.required_ruby_version '>= 2.6'
+  spec.required_ruby_version = '>= 2.6'
 end


### PR DESCRIPTION
Fixing syntax for a `spec.required_ruby_version`. Otherwise, the gem fails to build:
```
Invalid gemspec in [devdocs.gemspec]: wrong number of arguments (given 1, expected 0)
ERROR:  Error loading gemspec. Aborting.
```