### PR TITLE
Last modified attribute check

### DIFF
--- a/_includes/layout/page-updated.html
+++ b/_includes/layout/page-updated.html
@@ -1,4 +1,4 @@
-{%- if page.last_modified_at != nil and page.last_modified_at != "" -%}
+{%- if page.last_modified_at and page.last_modified_at != "" -%}
 <button class="page-updated spectrum-ActionButton spectrum-ActionButton--quiet">
   <img class="spectrum-Icon spectrum-Icon--sizeS" src="{{ site.baseurl }}/assets/i/icons/time.svg" alt="Updated" />
   <time class="spectrum-ActionButton-label" id="last-modified-at" itemprop="dateModified" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">

--- a/_includes/layout/page-updated.html
+++ b/_includes/layout/page-updated.html
@@ -1,4 +1,4 @@
-{%- if page.last_modified_at -%}
+{%- if page.last_modified_at != nil and page.last_modified_at != "" -%}
 <button class="page-updated spectrum-ActionButton spectrum-ActionButton--quiet">
   <img class="spectrum-Icon spectrum-Icon--sizeS" src="{{ site.baseurl }}/assets/i/icons/time.svg" alt="Updated" />
   <time class="spectrum-ActionButton-label" id="last-modified-at" itemprop="dateModified" datetime="{{ page.last_modified_at | date: "%Y-%m-%d" }}">

--- a/_includes/layout/sidebar-nav-tree-item.html
+++ b/_includes/layout/sidebar-nav-tree-item.html
@@ -4,7 +4,7 @@
 
 {% if include.page.title %}
 <li class="spectrum-SideNav-item {% if include.page.url == page.url %}is-selected{% endif %}">
-  <a class="spectrum-SideNav-itemLink ee-only" href="{{ site.baseurl }}{{ include.page.url }}">{% if include.page.menu_title %}{{ include.page.menu_title }}{% else %}{{ include.page.title }}{% endif %}</a>
+  <a class="spectrum-SideNav-itemLink" href="{{ site.baseurl }}{{ include.page.url }}">{% if include.page.menu_title %}{{ include.page.menu_title }}{% else %}{{ include.page.title }}{% endif %}</a>
   {% if children_size > 0 %}
     <ul class="spectrum-SideNav">
     {% for child in children %}


### PR DESCRIPTION
Bug fixes:

- This PR improves the logic of checking the `page.last_modified_at` variable. Sometimes the plugin can return an empty string as a date. It will not render the clock icon anymore.
- Also removes unused class from the menu item.