### PR TITLE
Allow ruby version from 2.4

### DIFF
--- a/devdocs.gemspec
+++ b/devdocs.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'jekyll', '>= 4.0'
   spec.add_development_dependency 'bundler', '>= 1.12'
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 2.4'
 end


### PR DESCRIPTION
Required by the OMS Docs project dependency on Docker image it uses.