### PR TITLE
Update the Lint Code Base check

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,6 +18,10 @@ on:
   pull_request:
     branches:
       - master
+    paths-ignore:
+      - '**.md'
+      - '**.html'
+      - '**.xml'
 
 ###############
 # Set the Job #
@@ -50,3 +54,4 @@ jobs:
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
           VALIDATE_MARKDOWN: false
+          VALIDATE_XML: false

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -49,4 +49,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           VALIDATE_HTML: false
-          VALIDATE_MD: false
+          VALIDATE_MARKDOWN: false


### PR DESCRIPTION
The SuperLinter syntax was changed just yesterday (github/super-linter@b69b2b1).
This also disables XML linter and configures the check to not trigger for file types that correspond to disabled linters (MD, HTML, XML).