### PR TITLE
Update facetFilters for devdocs search and fix version switcher in versionless doc sites

### DIFF
--- a/_includes/layout/header-scripts.html
+++ b/_includes/layout/header-scripts.html
@@ -10,7 +10,7 @@
     {
       label: "DevDocs",
       name: "devdocs",
-      facetFilters: [["guide_version: 2.3", "versionless: true"]],
+      facetFilters: [["guide_version: 2.4", "versionless: true"]],
       refinements: [
         {
           label: "Functional areas",

--- a/_includes/layout/version-switcher.html
+++ b/_includes/layout/version-switcher.html
@@ -1,3 +1,6 @@
+{% assign versions = site.versions %}
+
+{%- if versions.size > 1 -%}
 <div class="version-switcher">
 
 	<button id="version-switcher-button" class="spectrum-Picker spectrum-Picker--sizeM" data-toggle="dropdown"
@@ -17,3 +20,4 @@
 	</div>
 
 </div>
+{%- endif -%}


### PR DESCRIPTION
1. Use version 2.4 in `facetFilters` for devdocs indexing. Slack: [related thread](https://magento.slack.com/archives/C72EWLDHS/p1629762898100600?thread_ts=1629745121.099900&cid=C72EWLDHS) 
1. Eliminate version switcher in versionless docs. Fixes #91 