### PR TITLE
Link to choose issue type for Log an Issue

### DIFF
--- a/_includes/layout/github-links.html
+++ b/_includes/layout/github-links.html
@@ -8,7 +8,7 @@
   {%- endif -%}
   {%- if page.feedback_link == true -%}
     <a class="spectrum-ActionButton spectrum-ActionButton--quiet spectrum-ActionButton--sizeM spectrum-ActionGroup-item github-links"
-      href="{{ page.github_repo }}issues/new?title=Feedback on page: {{ page.url }}" target="_blank">
+      href="{{ page.github_repo }}issues/new/choose" target="_blank">
       <img class="spectrum-Icon spectrum-Icon--sizeS" src="{{ site.baseurl }}/assets/i/icons/bug.svg" alt="" />
       <span class="spectrum-ActionButton-label">Log an Issue</span>
     </a>


### PR DESCRIPTION
GitHub [recommends](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository) _using the upgraded multiple issue template builder or issue forms to create issue templates_.
It makes sense to make this a default behavior for the dependent projects and open the issue chooser on clicking **Log an Issue**.

### Preview

https://docs.magedevteam.com/234/user-guide/

### How to test

Open any topic on the preview and click on the **Log an Issue** at the upper left.