### PR TITLE
Link checker fix

### DIFF
--- a/_includes/layout/header.html
+++ b/_includes/layout/header.html
@@ -12,7 +12,7 @@
 	<link rel="stylesheet" href="https://use.typekit.net/iaw1apr.css">
 	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/app.css?ver=18" />
 	<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/print.css?ver=18" media="print" />
-	<script src="//assets.adobedtm.com/a7d65461e54e/f87b70cb627a/launch-b042bff6c581.min.js" async></script>
+	<script src="https://assets.adobedtm.com/a7d65461e54e/f87b70cb627a/launch-b042bff6c581.min.js" async></script>
 
 	{% include layout/header-styles.html %}
 	{% include layout/header-scripts.html %}


### PR DESCRIPTION
Fix a script link violation reported by the link checker:

```
script link //assets.adobedtm.com/a7d65461e54e/f87b70cb627a/launch-b042bff6c581.min.js is a protocol-relative URL, use explicit https:// instead
```

Previews:

- https://devdocs.magedevteam.com/725/
- https://docs.magedevteam.com/299/user-guide/
- https://docs.magedevteam.com/51/mbi/
- https://omsdocs.magedevteam.com/70/